### PR TITLE
Fix reporting coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       run: cargo clippy
     - id: coverage  
       uses: actions-rs/grcov@v0.1
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         verbose: true
+    - name: test
+      run: echo ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,4 @@ jobs:
     - uses: codecov/codecov-action@v3
       with:
         verbose: true
-    - name: test
-      run: echo ${{ steps.coverage.outputs.report }}
+        files: ${{ steps.coverage.outputs.report }}


### PR DESCRIPTION
The v1 version of the GH action is no longer maintained
and does not work. Additionally it seems that we need to
provide the path to the coverage report explicitly for it
to be actually sent.